### PR TITLE
Fix some holes in the protocol

### DIFF
--- a/docs/game-commands.md
+++ b/docs/game-commands.md
@@ -112,7 +112,7 @@ Requests destinationCards from the server. Step 1 of selecting destination cards
 }
 ```
 
-### `selectDestinations` Command
+### `dealCards` Command
 Client Command.
 
 Sends destinationCards to the client, as well as the trainCards for that player. Step 2 of selecting destination cards.


### PR DESCRIPTION
1. The train cards need to be send to the client in the `selectDestinations` command. I think this is the best place for it because (1) it shouldn't go in the `updatePlayer` command since a player shouldn't know about what cards other players have
2. Add a turnOrder to the `player` object - so the client knows explicitly what order to display them in