### PR TITLE
Make sure AuthTokens are updated in the user object when a new one is…

### DIFF
--- a/server/src/models/AuthTokens.kt
+++ b/server/src/models/AuthTokens.kt
@@ -32,6 +32,7 @@ object AuthTokens {
         val token = BigInteger(bytes).toString(16)
 
         authTokens[token] = user
+        user.authToken = token
 
         return token
     }


### PR DESCRIPTION
Fix bug where if a user logged in after their user had been serialized, their authtoken would not be updated and if the server reloaded, the old authtoken would be loaded in.